### PR TITLE
ci: install Chrome via action, run Selenium headless; 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,28 +19,43 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
-          cache: 'gradle'
+          cache: gradle
 
-      - name: Make gradlew executable
-        run: chmod +x gradlew
+      # Install Chrome (stable) in a supported, reproducible way
+      - name: Set up Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      # - name: Make gradlew executable
+      #  run: chmod +x gradlew
 
       - name: Run tests (headless)
         run: ./gradlew test -Dheadless=true
+        shell: bash
 
+      # --- REPORTING STEPS ---
       # Upload Allure results (raw) as an artifact
-      - name: Upload allure-results
-        uses: actions/upload-artifact@v4
+      - name: Upload Allure results
         if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: allure-results
           path: build/allure-results
 
-      # Also upload JUnit XML for quick inspection (optional)
-      - name: Upload test reports (JUnit XML / Gradle)
-        uses: actions/upload-artifact@v4
+      # Upload JUnit XML for quick inspection
+      - name: Upload JUnit & Gradle reports
         if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: junit-and-gradle-reports
           path: |
             build/test-results/test
             build/reports/tests/test
+
+      - name: Upload HTML test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test

--- a/src/test/java/tests/LoginTest.java
+++ b/src/test/java/tests/LoginTest.java
@@ -27,12 +27,15 @@ public class LoginTest {
     void setUp() {
         ChromeOptions options = new ChromeOptions();
         // Headless in CI
-        if (System.getenv("CI") != null || Boolean.parseBoolean(System.getProperty("headless", "false"))) {
+        if (System.getenv("CI") != null ||
+                Boolean.parseBoolean(System.getProperty("headless", "false"))) {
             options.addArguments("--headless=new");
             options.addArguments("--window-size=1920,1080");
+            options.addArguments("--no-sandbox");              // <-- add for CI
+            options.addArguments("--disable-dev-shm-usage");   // <-- add for CI
         }
 
-        driver = new ChromeDriver();
+        driver = new ChromeDriver(options);
         driver.manage().window().maximize();
         driver.get("https://www.saucedemo.com/"); // Demo e-commerce site for testing
 


### PR DESCRIPTION
- Uses browser-actions/setup-chrome@v1
- Selenium runs headless (--no-sandbox, --disable-dev-shm-usage)